### PR TITLE
Style/Button

### DIFF
--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -2,36 +2,58 @@ import { TextStyle } from "@/types/text-style";
 
 const CSS_CONFIG = {
   green: {
-    default: "bg-green-500 text-white hover:bg-green-300",
-    disabled: "bg-grey-300 text-grey-500",
+    primary: {
+      default: "bg-green-500 text-white hover:bg-green-300",
+      disabled: "bg-grey-300 text-grey-500",
+    },
+    secondary: {
+      default:
+        "bg-green-50 border border-green-500 text-green-500 hover:bg-white",
+      disabled: "bg-white border border-grey-300 text-grey-500",
+    },
   },
   grey: {
-    default: "bg-grey-200 text-grey-900 hover:bg-grey-300",
-    disabled: "bg-grey-100 text-grey-400",
+    primary: {
+      default: "bg-grey-200 text-grey-900 hover:bg-grey-300",
+      disabled: "bg-grey-100 text-grey-400",
+    },
+    secondary: {
+      default: "bg-grey-200 text-grey-900 hover:bg-grey-300",
+      disabled: "bg-grey-100 text-grey-400",
+    },
   },
   yellow: {
-    default: "bg-yellow-500 text-white hover:bg-yellow-300",
-    disabled: "bg-grey-300 text-grey-500",
+    primary: {
+      default: "bg-yellow-500 text-white hover:bg-yellow-300",
+      disabled: "bg-grey-300 text-grey-500",
+    },
+    secondary: {
+      default:
+        "bg-yellow-50 border border-yellow-500 text-yellow-500 hover:bg-yellow-50",
+      disabled: "bg-white border border-grey-300 text-grey-500",
+    },
   },
 };
 
 export default function Button({
   color,
-  type,
+  type = "primary",
+  state,
   onClick,
   text,
   textStyle = "body2",
 }: {
   color: "green" | "grey" | "yellow";
-  type: "default" | "disabled";
-  onClick: () => void;
+  type?: "primary" | "secondary";
+  state: "default" | "disabled";
+  onClick?: React.MouseEventHandler<HTMLButtonElement>;
   text: string;
   textStyle?: TextStyle;
 }) {
   return (
     <button
-      disabled={type === "disabled"}
-      className={`rounded-lg px-4 h-full ${CSS_CONFIG[color][type]} ${textStyle}`}
+      disabled={state === "disabled"}
+      className={`rounded-lg w-full h-full ${CSS_CONFIG[color][type][state]} ${textStyle}`}
       onClick={onClick}
     >
       {text}


### PR DESCRIPTION
# Task
<!--새로 작성, 변경된 컴포넌트-->
## Component
- [x] Button `src/components/common/Button.tsx`

# Details
<!--새롭게 알게된 사항, 트러블 슈팅-->
## Button customize
```typescript
interface ButtonProps {
  color: "green" | "grey" | "yellow";
  type?: "primary" | "secondary";
  state: "default" | "disabled";
  onClick?: React.MouseEventHandler<HTMLButtonElement>;
  text: string;
  textStyle?: TextStyle;
}
```
```typescript
const CSS_CONFIG = {
  green: {
    primary: {
      default: "bg-green-500 text-white hover:bg-green-300",
      disabled: "bg-grey-300 text-grey-500",
    },
    secondary: {
      default:
        "bg-green-50 border border-green-500 text-green-500 hover:bg-white",
      disabled: "bg-white border border-grey-300 text-grey-500",
    },
  },
  grey: {
    primary: {
      default: "bg-grey-200 text-grey-900 hover:bg-grey-300",
      disabled: "bg-grey-100 text-grey-400",
    },
    secondary: {
      default: "bg-grey-200 text-grey-900 hover:bg-grey-300",
      disabled: "bg-grey-100 text-grey-400",
    },
  },
  yellow: {
    primary: {
      default: "bg-yellow-500 text-white hover:bg-yellow-300",
      disabled: "bg-grey-300 text-grey-500",
    },
    secondary: {
      default:
        "bg-yellow-50 border border-yellow-500 text-yellow-500 hover:bg-yellow-50",
      disabled: "bg-white border border-grey-300 text-grey-500",
    },
  },
};
```
일일이 tailwindcss를 입력하는 게 번거롭다, style util 함수로 따로 뺄 수 있을 것 같은데, 추후 고민할 문제로 남겨두겠다.

- [ ] color, text-color, border-color 등 공통 디자인의 시스템 util 함수

# Reference
[props로 전달하는 onClick 함수의 타입 지정하기 - 이나리 velog](https://velog.io/@eenaree/props-onClick-type)



